### PR TITLE
MIST doesn't try to rewrite properties on already mist:ed files.

### DIFF
--- a/Mathtone.MIST.Builder/Processors/TypeProcessor.cs
+++ b/Mathtone.MIST.Builder/Processors/TypeProcessor.cs
@@ -23,8 +23,10 @@ namespace Mathtone.MIST.Processors {
 		public void Process(TypeDefinition typeDef) {
 
 			var notifierAttr = typeDef.GetAttribute(typeof(NotifierAttribute));
-
+            
 			if (notifierAttr != null) {
+
+                typeDef.CustomAttributes.Remove(notifierAttr); //Make sure we only ever MIST a property ONCE (mostly useful for unit tests)
 
 				//Use explicit mode if not otherwise specified
 				var mode = NotificationMode.Explicit;


### PR DESCRIPTION
Implemented by simply removing the custom attribute [Notifier] when the class is processed.
