### PR TITLE
Cleaned up two tests a bit

### DIFF
--- a/Tests/Mathtone.MIST.Tests.UnitTests/UnitTests.cs
+++ b/Tests/Mathtone.MIST.Tests.UnitTests/UnitTests.cs
@@ -198,20 +198,21 @@ namespace Mathtone.MIST.Tests {
 		[TestMethod]
 		public void OnSet_for_New_ReferenceTypes() {
 			var notifier = new ExplicitValueTypeNotifier_Specialized();
-			notifier.OnSetVirtualObject = new object();
-			notifier.OnSetVirtualObject = notifier.OnSetVirtualObject;
+            var expectedObject = new object();
+            notifier.OnSetVirtualObject = expectedObject;
+            Assert.AreEqual(expectedObject, notifier.OnSetVirtualObject);
+			notifier.OnSetVirtualObject = expectedObject;
 			Assert.AreEqual(2, notifier.ChangeCount);
 		}
 
 		[TestMethod]
 		public void OnChange_for_New_ReferenceTypes() {
 			var notifier = new ExplicitValueTypeNotifier_Specialized();
-			var obj = new object();
-			notifier.OnChangeVirtualObject = obj;
-			notifier.OnChangeVirtualObject = obj;
-			notifier.OnChangeVirtualObject = notifier.OnSetVirtualObject;
-			//I think 2 changes is right here, the first is a change from null 
-			Assert.AreEqual(2, notifier.ChangeCount);
+			var expectedObject = new object();
+			notifier.OnChangeVirtualObject = expectedObject;
+            Assert.AreEqual(expectedObject, notifier.OnChangeVirtualObject);
+            notifier.OnChangeVirtualObject = expectedObject;
+            Assert.AreEqual(1, notifier.ChangeCount);
 		}
 
 		#endregion Class inheritance


### PR DESCRIPTION
Good catch that I referenced the wrong object in OnChange_for_New_ReferenceTypes(). 
I cleaned it up and at the same time verifying the getter reads back the same value that is set.
The tests are still passing with your implementation, but look a tiny bit better.

Great work on getting most tests to pass!
